### PR TITLE
Allow motherduck_token to be passed in via header

### DIFF
--- a/ob-duckdb.el
+++ b/ob-duckdb.el
@@ -85,6 +85,7 @@ displayed with its original structure and any colorization intact.")
     (echo      . :any)  ; Echo commands
     (bail      . :any)  ; Exit on error
     (async     . :any)  ; Execute asynchronously
+    (md_token  . :any)  ; Pass in motherduck_token
     (output    . :any)) ; Output handling (e.g., "buffer")
   "DuckDB-specific header arguments.
 These header arguments control how DuckDB executes queries and formats results:
@@ -98,6 +99,7 @@ separator: Column separator for output
 echo:      Echo commands being executed (on/off)
 bail:      Exit on error (on/off)
 async:     Execute asynchronously (yes/no)
+md_token:  Motherduck token
 output:    Control result display (\"buffer\" for dedicated output)")
 
 ;;; Customization Options
@@ -416,6 +418,7 @@ directives are properly translated to DuckDB's native configuration system."
         (nullvalue (cdr (assq :nullvalue params)))
         (separator (cdr (assq :separator params)))
         (echo (cdr (assq :echo params)))
+        (md_token (cdr (assq :md_token params)))
         (bail (cdr (assq :bail params))))
 
     ;; Use with-temp-buffer for string building which benchmarks showed was fastest
@@ -429,6 +432,7 @@ directives are properly translated to DuckDB's native configuration system."
       (when headers   (insert (format ".headers %s\n"   (if (string= headers "off") "off" "on"))))
       (when echo      (insert (format ".echo %s\n"      (if (string= echo    "off") "off" "on"))))
       (when bail      (insert (format ".bail %s\n"      (if (string= bail    "off") "off" "on"))))
+      (when md_token  (setenv "motherduck_token" md_token))
 
       ;; Return the buffer contents if we added any commands
       (when (> (buffer-size) 0)


### PR DESCRIPTION
Duckdb can query [Motherduck](https://motherduck.com/) databases.  When you connect with a command line duckdb call, like

```
duckdb 'md:mydbname'
```

and then execute the first query, duckdb will open a browser window so you can authenticate to motherduck.   

```
D use myorg.myschema;
Attempting to automatically open the SSO authorization page in your default browser.
Please open this link to login into your account: https://auth.motherduck.com/activate?user_code=REDACTED


Token successfully retrieved ✅

You can display the token and store it as an environment variable to avoid having to log in again:
  PRAGMA PRINT_MD_TOKEN;
```

Once you do that you can print the access token by running (within duckdb)

```
D PRAGMA PRINT_MD_TOKEN;
export motherduck_token='redacted'
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ 0 rows  │
└─────────┘
D 
```

This PR allows you to pass in that token like this:

```
#+begin_src duckdb :db "md:parsyl" :md_token REDACTED :format org-table
  select id, created_at from people order by created_at;
#+end_src
```
And query motherduck.
